### PR TITLE
Check if chmod is successful

### DIFF
--- a/src/Keboola/SSHTunnel/SSH.php
+++ b/src/Keboola/SSHTunnel/SSH.php
@@ -126,7 +126,9 @@ class SSH
         $fileName = (string) tempnam('/tmp/', 'ssh-key-');
 
         file_put_contents($fileName, $key);
-        chmod($fileName, 0600);
+        if (!chmod($fileName, 0600)) {
+            throw new SSHException("Cannot set permissions to SSH private key file.");
+        }
 
         return (string) realpath($fileName);
     }


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/COM-1091

Klient ma problem:
- Azure stack.
- `db-writer-mysql`
- SSH connection nahodne skonci s chybou:
![image](https://user-images.githubusercontent.com/19371734/133070856-9a97bafb-56f8-4640-8072-e9d99ac41fd9.png)
- V kode `chmod` je, pouziva sa aktualna verzia kniznice.
- U `chmod` sa nekontroluje ci presiel, ci nevrati `false`.
- Preto tam pridavam tuto kontrolu(lebo uz neviem kde inde moze byt problem).
- Ak to spadne, tak je nejaky problem so strojom, kde to bezi.
