### PR TITLE
fix: enable legacy ssh-rsa algorithm for compatibility with older SSH servers

### DIFF
--- a/src/Keboola/SSHTunnel/SSH.php
+++ b/src/Keboola/SSHTunnel/SSH.php
@@ -93,6 +93,12 @@ class SSH
             'ExitOnForwardFailure=yes',
             '-o',
             'StrictHostKeyChecking=no',
+            // Enable legacy ssh-rsa algorithm for compatibility with older SSH servers
+            // OpenSSH 8.8+ disabled ssh-rsa by default due to SHA-1 deprecation
+            '-o',
+            'PubkeyAcceptedAlgorithms=+ssh-rsa',
+            '-o',
+            'HostKeyAlgorithms=+ssh-rsa',
         ];
 
         if (isset($config['compression']) && $config['compression'] === true) {

--- a/tests/Keboola/SSHTunnel/SSHTest.php
+++ b/tests/Keboola/SSHTunnel/SSHTest.php
@@ -66,7 +66,23 @@ class SSHTest extends TestCase
 
         $this->assertDbConnection($config);
     }
-    
+
+    public function testOpenTunnelIncludesLegacyAlgorithmOptions(): void
+    {
+        $config = $this->getConfig();
+
+        $ssh = new SSH();
+        $process = $ssh->openTunnel($config);
+
+        // Verify legacy ssh-rsa algorithm options are included for compatibility with older servers
+        // OpenSSH 8.8+ disabled ssh-rsa by default, so we need to explicitly enable it
+        $this->assertStringContainsString('PubkeyAcceptedAlgorithms=+ssh-rsa', $process->getCommandLine());
+        $this->assertStringContainsString('HostKeyAlgorithms=+ssh-rsa', $process->getCommandLine());
+        $this->assertEquals(0, $process->getExitCode());
+
+        $this->assertDbConnection($config);
+    }
+
     public function testOpenTunnelWrongHost(): void
     {
         $this->expectException('PDOException');

--- a/tests/env/sshproxy/Dockerfile
+++ b/tests/env/sshproxy/Dockerfile
@@ -12,6 +12,11 @@ RUN echo 'root:root' |chpasswd
 RUN sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
 
+# Enable legacy ssh-rsa algorithm for testing compatibility with older clients
+# OpenSSH 8.8+ disabled ssh-rsa by default due to SHA-1 deprecation
+RUN echo "PubkeyAcceptedAlgorithms +ssh-rsa" >> /etc/ssh/sshd_config
+RUN echo "HostKeyAlgorithms +ssh-rsa" >> /etc/ssh/sshd_config
+
 RUN mkdir ~/.ssh
 RUN echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2tGpPt3qrI/G4QOJeP7kA2ihC9U/cY42GNZuedrKocNGGQBgvjGNRP1kCexXeaJ25KUti+tFbPjVrdt6xhqALiwUupSYFusaAVEDcwl6KLMGAOHWD0X7hdraL3w4ATyNTBvowyc9ZvsollNyTUqDWxN2USTfk89Xd+S2noAfoCUJd4fMEmBeAAqlYTajHGKSKYcRGokxci7dyaXoHEQgsd0giZWIZATNUkWTV36bTnGjMxz4pK6LHNglQRNO4GpxQI5Bmie60gVcOIQAhmbrTq9bwcoLq6SGBOUO/Vr6ZnLcI8h4W50HSNUeXKtFMeNMgzDgS8x4Ow0XLEpjujRGh miroslavcillik@Miroslavs-MacBook-Air.local" >> ~/.ssh/authorized_keys
 


### PR DESCRIPTION
## Summary

Fixes SSH tunnel connection failures with older SSH servers that only support the legacy `ssh-rsa` signature algorithm.

## Why

After deploying PR #18 (which updated the PHP image from 7.1 to 8.3 and sshproxy from Ubuntu 14.04 to 22.04), customers started experiencing authentication failures with the error:

```
sign_and_send_pubkey: no mutual signature supported
Permission denied, please try again.
```

This happened because:
1. The new PHP 8.3 image (Debian Bookworm) includes OpenSSH 9.x
2. OpenSSH 8.8+ disabled the legacy `ssh-rsa` signature algorithm by default (due to SHA-1 deprecation)
3. Some customer SSH servers only support the legacy `ssh-rsa` algorithm
4. No mutual algorithm = connection fails

## Context

- Related issue: The error occurred in mysql extractor job 56926477
- The RSA key format (`ssh-rsa AAAAB3...`) is still valid, but the signature algorithm used during authentication was the problem
- This is a known compatibility issue with OpenSSH 8.8+ documented in the [OpenSSH release notes](https://www.openssh.com/txt/release-8.8)

## Approach

Added SSH options to explicitly enable the legacy `ssh-rsa` algorithm alongside modern defaults:

```
-o PubkeyAcceptedAlgorithms=+ssh-rsa
-o HostKeyAlgorithms=+ssh-rsa
```

The `+` prefix means "add to defaults" - this preserves all modern algorithms (rsa-sha2-256, rsa-sha2-512, ssh-ed25519, etc.) while also offering the legacy algorithm for backward compatibility.

## Test plan

- [x] Verify tests pass in CI with `SSH_KEY_PRIVATE` secret
- [ ] Test with a customer configuration that was previously failing
- [ ] Verify modern SSH servers still work (they'll negotiate better algorithms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)